### PR TITLE
 [FIX] multi_company_account : remove duplicated company_id field on account invoice tree view

### DIFF
--- a/multi_company_account/views/view_account_invoice.xml
+++ b/multi_company_account/views/view_account_invoice.xml
@@ -17,14 +17,4 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
-    <record id="view_account_invoice_tree" model="ir.ui.view">
-        <field name="model">account.invoice</field>
-        <field name="inherit_id" ref="account.invoice_tree" />
-        <field name="arch" type="xml">
-            <field name="type" position="after">
-                <field name="company_id" groups="base.group_multi_company" />
-            </field>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
In v12, the field is present in the basic view.